### PR TITLE
feat: Curvilinear waterway labels (GEOM_TEXT_LINE)

### DIFF
--- a/src/nav_types.hpp
+++ b/src/nav_types.hpp
@@ -18,6 +18,7 @@ const uint8_t GEOM_POINT = 1;
 const uint8_t GEOM_LINESTRING = 2;
 const uint8_t GEOM_POLYGON = 3;
 const uint8_t GEOM_TEXT = 4;
+const uint8_t GEOM_TEXT_LINE = 5;
 
 #pragma pack(push, 1)
 struct PackHeader

--- a/src/osmium_handler.hpp
+++ b/src/osmium_handler.hpp
@@ -289,6 +289,10 @@ public:
 
         // Road labels
         create_road_label(feat.points, feat.ref, feat.old_ref, feat.highway_type, feat.color_rgb565);
+
+        // Waterway labels
+        if (tags.count("waterway"))
+            create_waterway_label(feat.points, tags.at("waterway"), feat.name);
     }
 
     void area(const osmium::Area& a)
@@ -373,6 +377,7 @@ public:
     size_t stats_filtered = 0;
     size_t stats_points = 0;
     size_t stats_text_labels = 0;
+    size_t stats_waterway_labels = 0;
 
     double bbox_min_lon = 180, bbox_min_lat = 90;
     double bbox_max_lon = -180, bbox_max_lat = -90;
@@ -382,6 +387,7 @@ private:
     MappedStore& store;
     int min_zoom_range, max_zoom_range;
     std::unordered_map<std::string, int> road_label_counters;
+    std::unordered_map<std::string, int> waterway_label_counters;
 
     std::string get_highway_type(const std::unordered_map<std::string, std::string>& tags)
     {
@@ -592,6 +598,65 @@ private:
         feat.ring_ends.push_back(1);
         feat.coords_candidates = candidates;
         text_features_vec.push_back(std::move(feat));
+    }
+
+    void create_waterway_label(const std::vector<Point>& coords,
+                               const std::string& waterway_type,
+                               const std::string& name)
+    {
+        if (name.empty()) return;
+        if (waterway_type != "river" && waterway_type != "stream" && waterway_type != "canal")
+            return;
+
+        int spacing;
+        if (waterway_type == "river") spacing = 4;
+        else if (waterway_type == "canal") spacing = 8;
+        else spacing = 12;
+
+        waterway_label_counters[name]++;
+        if (waterway_label_counters[name] % spacing != 1)
+            return;
+
+        int label_idx = waterway_label_counters[name] / spacing;
+
+        int min_zoom;
+        if (waterway_type == "river") min_zoom = 10;
+        else if (waterway_type == "canal") min_zoom = 12;
+        else min_zoom = 14;
+
+        if (min_zoom > max_zoom_range) return;
+        if (coords.size() < 2) return;
+
+        // Alternate sub-segment position to spread labels along the waterway
+        double start_ratio, end_ratio;
+        switch (label_idx % 3)
+        {
+            case 0: start_ratio = 0.10; end_ratio = 0.55; break;
+            case 1: start_ratio = 0.45; end_ratio = 0.90; break;
+            default: start_ratio = 0.25; end_ratio = 0.75; break;
+        }
+        size_t i_start = static_cast<size_t>(coords.size() * start_ratio);
+        size_t i_end = static_cast<size_t>(coords.size() * end_ratio);
+        if (i_end <= i_start) i_end = i_start + 1;
+        if (i_end >= coords.size()) i_end = coords.size() - 1;
+        std::vector<Point> path(coords.begin() + i_start, coords.begin() + i_end + 1);
+        if (path.size() < 2) return;
+
+        Feature feat;
+        feat.id = 0;
+        feat.geom_type = GEOM_TEXT_LINE;
+        feat.color_rgb565 = 0x4C16; // #4a80b0 dark blue
+        feat.bg_color_rgb565 = 0;
+        feat.border_color_rgb565 = 0;
+        feat.zoom_priority = utils::pack_zoom_priority(min_zoom, 12);
+        feat.font_size = 0;
+        std::string name_trunc = name.substr(0, 255);
+        feat.text.assign(name_trunc.begin(), name_trunc.end());
+        feat.population = 0;
+        feat.points = std::move(path);
+        feat.ring_ends.push_back(static_cast<uint32_t>(feat.points.size()));
+        text_features_vec.push_back(std::move(feat));
+        stats_waterway_labels++;
     }
 };
 

--- a/src/tile_processor.hpp
+++ b/src/tile_processor.hpp
@@ -94,14 +94,19 @@ private:
     std::vector<PlacedLabel> resolve_text_labels(const std::vector<Feature>& all_text, int zoom)
     {
         std::vector<PlacedLabel> result;
-        std::vector<const Feature*> place_names, road_labels;
+        std::vector<const Feature*> place_names, road_labels, waterway_labels;
 
         for (const auto& f : all_text)
         {
             int min_z = f.zoom_priority >> 4;
             if (min_z > zoom) continue;
-            if (f.geom_type != GEOM_TEXT) continue;
             if (f.points.empty()) continue;
+            if (f.geom_type == GEOM_TEXT_LINE)
+            {
+                waterway_labels.push_back(&f);
+                continue;
+            }
+            if (f.geom_type != GEOM_TEXT) continue;
             if (f.coords_candidates.empty())
                 place_names.push_back(&f);
             else
@@ -133,6 +138,24 @@ private:
             for (int dx = -1; dx <= 1; ++dx)
                 for (int dy = -1; dy <= 1; ++dy)
                     tiles.push_back({tx + dx, ty + dy});
+            return tiles;
+        };
+
+        auto expand_tiles_bbox = [&](double lon0, double lat0, double lon1, double lat1) -> std::vector<TileCoord> {
+            int tx0 = static_cast<int>(utils::lon_to_x(lon0, zoom));
+            int tx1 = static_cast<int>(utils::lon_to_x(lon1, zoom));
+            int ty0 = static_cast<int>(utils::lat_to_y(lat0, zoom));
+            int ty1 = static_cast<int>(utils::lat_to_y(lat1, zoom));
+            if (ty0 > ty1) std::swap(ty0, ty1);
+            std::unordered_set<int64_t> seen;
+            std::vector<TileCoord> tiles;
+            for (int tx = tx0; tx <= tx1; ++tx)
+                for (int ty = ty0; ty <= ty1; ++ty)
+                {
+                    int64_t key = ((int64_t)tx << 32) | (int64_t)(uint32_t)ty;
+                    if (seen.insert(key).second)
+                        tiles.push_back({tx, ty});
+                }
             return tiles;
         };
 
@@ -170,6 +193,28 @@ private:
                 }
             }
             (void)placed;
+        }
+
+        // Waterway labels — collision via path bbox + minimum spacing
+        double ww_min_margin = tile_w_deg * 3;  // at least 3 tiles of spacing between labels
+        for (const auto* wf : waterway_labels)
+        {
+            double min_lon = 180, max_lon = -180, min_lat = 90, max_lat = -90;
+            for (const auto& pt : wf->points)
+            {
+                if (pt.lon < min_lon) min_lon = pt.lon;
+                if (pt.lon > max_lon) max_lon = pt.lon;
+                if (pt.lat < min_lat) min_lat = pt.lat;
+                if (pt.lat > max_lat) max_lat = pt.lat;
+            }
+            double margin_lon = std::max(ww_min_margin, (max_lon - min_lon) * 0.5);
+            double margin_lat = std::max(ww_min_margin, (max_lat - min_lat) * 0.5);
+            Box box{min_lon - margin_lon, min_lat - margin_lat, max_lon + margin_lon, max_lat + margin_lat};
+            if (!check_overlap(box))
+            {
+                placed_boxes.push_back(box);
+                result.push_back({*wf, expand_tiles_bbox(min_lon, min_lat, max_lon, max_lat)});
+            }
         }
 
         return result;
@@ -1099,9 +1144,11 @@ private:
             written++;
         }
 
+        // Text features (GEOM_TEXT)
         for (const auto* label : tile_labels)
         {
             if (written >= 0xFFFE) break;
+            if (label->geom_type != GEOM_TEXT) continue;
 
             double lon = label->points[0].lon, lat = label->points[0].lat;
             int16_t px = (int16_t)((lon - lmin) / (lmax - lmin) * 4096);
@@ -1141,6 +1188,57 @@ private:
                               (uint8_t)(coord_count & 0xFF), (uint8_t)(coord_count >> 8),
                               (uint8_t)(text_payload.size() & 0xFF), (uint8_t)(text_payload.size() >> 8)};
             buffer.insert(buffer.end(), th2, th2 + 13);
+            buffer.insert(buffer.end(), text_payload.begin(), text_payload.end());
+            written++;
+        }
+
+        // Curvilinear text features (GEOM_TEXT_LINE)
+        for (const auto* label : tile_labels)
+        {
+            if (written >= 0xFFFE) break;
+            if (label->geom_type != GEOM_TEXT_LINE) continue;
+            if (label->points.size() < 2) continue;
+
+            std::vector<uint8_t> text_payload;
+            uint8_t path_count = (uint8_t)std::min((size_t)255, label->points.size());
+            text_payload.push_back(path_count);
+
+            int min_px = 32767, min_py = 32767, max_px = -32768, max_py = -32768;
+            for (uint8_t i = 0; i < path_count; ++i)
+            {
+                double lon = label->points[i].lon, lat = label->points[i].lat;
+                int16_t px = (int16_t)((lon - lmin) / (lmax - lmin) * 4096);
+                double m_y = utils::lat_to_mercator_y(lat);
+                int16_t py = (int16_t)((t_max_merc - m_y) / merc_range * 4096);
+                text_payload.push_back(px & 0xFF); text_payload.push_back(px >> 8);
+                text_payload.push_back(py & 0xFF); text_payload.push_back(py >> 8);
+                if (px < min_px) min_px = px;
+                if (px > max_px) max_px = px;
+                if (py < min_py) min_py = py;
+                if (py > max_py) max_py = py;
+            }
+
+            const auto& text_bytes = label->text;
+            uint8_t text_len = (uint8_t)text_bytes.size();
+            text_payload.push_back(text_len);
+            text_payload.insert(text_payload.end(), text_bytes.begin(), text_bytes.end());
+
+            int pad = (4 - (text_payload.size() % 4)) % 4;
+            for (int p = 0; p < pad; ++p) text_payload.push_back(0);
+
+            uint16_t coord_count = (uint16_t)(text_payload.size() / 4);
+
+            uint8_t bx0 = (uint8_t)std::max(0, std::min(255, min_px >> 4));
+            uint8_t by0 = (uint8_t)std::max(0, std::min(255, min_py >> 4));
+            uint8_t bx1 = (uint8_t)std::max(0, std::min(255, max_px >> 4));
+            uint8_t by1 = (uint8_t)std::max(0, std::min(255, max_py >> 4));
+
+            uint8_t th[13] = {GEOM_TEXT_LINE, (uint8_t)(label->color_rgb565 & 0xFF), (uint8_t)(label->color_rgb565 >> 8),
+                             label->zoom_priority, label->font_size,
+                             bx0, by0, bx1, by1,
+                             (uint8_t)(coord_count & 0xFF), (uint8_t)(coord_count >> 8),
+                             (uint8_t)(text_payload.size() & 0xFF), (uint8_t)(text_payload.size() >> 8)};
+            buffer.insert(buffer.end(), th, th + 13);
             buffer.insert(buffer.end(), text_payload.begin(), text_payload.end());
             written++;
         }

--- a/tile_viewer.py
+++ b/tile_viewer.py
@@ -43,6 +43,7 @@ GEOM_POINT = 1
 GEOM_LINESTRING = 2
 GEOM_POLYGON = 3
 GEOM_TEXT = 4
+GEOM_TEXT_LINE = 5
 
 
 def deg2num(lat_deg: float, lon_deg: float, zoom: int) -> Tuple[float, float]:
@@ -213,6 +214,18 @@ def read_nav_tile(path: str, tile_x: int, tile_y: int) -> List[NavFeature]:
                         text_len = payload[4]
                         feature.text = payload[5:5 + text_len].decode('utf-8', errors='replace')
                         feature.font_size = feature.width
+                elif feature.geom_type == GEOM_TEXT_LINE:
+                    if len(payload) >= 1:
+                        path_count = payload[0]
+                        off = 1
+                        for _ in range(path_count):
+                            px, py = struct.unpack('<hh', payload[off:off+4])
+                            feature.coords.append((px, py))
+                            off += 4
+                        text_len = payload[off]
+                        off += 1
+                        feature.text = payload[off:off + text_len].decode('utf-8', errors='replace')
+                        feature.font_size = feature.width
                 else:
                     offset = 0
                     last_x, last_y = 0, 0
@@ -269,6 +282,18 @@ def read_nav_tile_from_bytes(data: bytes, tile_x: int, tile_y: int) -> List[NavF
                     feature.coords.append((px, py))
                     text_len = payload[4]
                     feature.text = payload[5:5 + text_len].decode('utf-8', errors='replace')
+                    feature.font_size = feature.width
+            elif feature.geom_type == GEOM_TEXT_LINE:
+                if len(payload) >= 1:
+                    path_count = payload[0]
+                    off = 1
+                    for _ in range(path_count):
+                        px, py = struct.unpack('<hh', payload[off:off+4])
+                        feature.coords.append((px, py))
+                        off += 4
+                    text_len = payload[off]
+                    off += 1
+                    feature.text = payload[off:off + text_len].decode('utf-8', errors='replace')
                     feature.font_size = feature.width
             else:
                 offset = 0
@@ -523,7 +548,7 @@ class NAVViewer:
         # FOUR-PASS RENDERING: bridges (needs_casing) drawn after at-grade roads
         # Pass 1: Non-bridge, non-text features (polygons + at-grade road cores)
         for feature in features:
-            if feature.geom_type == GEOM_TEXT:
+            if feature.geom_type in (GEOM_TEXT, GEOM_TEXT_LINE):
                 continue
             if feature.geom_type == GEOM_LINESTRING and feature.needs_casing:
                 continue
@@ -543,6 +568,8 @@ class NAVViewer:
         for feature in features:
             if feature.geom_type == GEOM_TEXT:
                 self._render_feature(surface, feature)
+            elif feature.geom_type == GEOM_TEXT_LINE:
+                self._render_text_line(surface, feature)
 
         if self.show_tile_grid:
             self._draw_tile_grid(surface)
@@ -642,6 +669,89 @@ class NAVViewer:
         # Draw casing: wider than the road core with smooth joins
         casing_width = feature.width + 1.0  # +1px border (0.5px each side)
         self._draw_smooth_line(surface, casing_color, pts, casing_width)
+
+    def _render_text_line(self, surface: pygame.Surface, feature: NavFeature):
+        """Render curvilinear text along a polyline path."""
+        if len(feature.coords) < 2 or not feature.text:
+            return
+
+        pts = [self._tile_coord_to_screen(feature.tile_x, feature.tile_y, x, y)
+               for x, y in feature.coords]
+
+        # Cumulative distances along path
+        dists = [0.0]
+        for i in range(1, len(pts)):
+            dx = pts[i][0] - pts[i-1][0]
+            dy = pts[i][1] - pts[i-1][1]
+            dists.append(dists[-1] + math.hypot(dx, dy))
+        path_length = dists[-1]
+        if path_length < 1:
+            return
+
+        color = rgb565_to_rgb888(feature.color_rgb565)
+        font_sizes = {0: 15, 1: 17, 2: 20}
+        size = font_sizes.get(feature.font_size, 15)
+        text_font = pygame.font.SysFont(None, size)
+
+        # Measure total text width
+        char_widths = []
+        for ch in feature.text:
+            w = text_font.size(ch)[0]
+            char_widths.append(w)
+        total_text_w = sum(char_widths)
+
+        if total_text_w > path_length:
+            return
+
+        # Check if text runs right-to-left on screen — if so, reverse
+        start_d = (path_length - total_text_w) / 2.0
+        end_d = start_d + total_text_w
+        sx, sy = self._interp_path(pts, dists, start_d)
+        ex, ey = self._interp_path(pts, dists, end_d)
+        if ex < sx:
+            pts = pts[::-1]
+            dists = [0.0]
+            for i in range(1, len(pts)):
+                dx = pts[i][0] - pts[i-1][0]
+                dy = pts[i][1] - pts[i-1][1]
+                dists.append(dists[-1] + math.hypot(dx, dy))
+
+        cursor = (path_length - total_text_w) / 2.0
+        for i, ch in enumerate(feature.text):
+            cw = char_widths[i]
+            mid_d = cursor + cw / 2.0
+            cx, cy = self._interp_path(pts, dists, mid_d)
+
+            # Angle from nearby points
+            d0 = max(0, mid_d - 1)
+            d1 = min(path_length, mid_d + 1)
+            ax, ay = self._interp_path(pts, dists, d0)
+            bx, by = self._interp_path(pts, dists, d1)
+            angle = math.degrees(math.atan2(-(by - ay), bx - ax))
+
+            char_surf = text_font.render(ch, True, color)
+            rotated = pygame.transform.rotate(char_surf, angle)
+            rect = rotated.get_rect(center=(int(cx), int(cy)))
+            surface.blit(rotated, rect)
+            cursor += cw
+
+    @staticmethod
+    def _interp_path(pts, dists, d):
+        """Interpolate a position along a polyline at cumulative distance d."""
+        if d <= 0:
+            return float(pts[0][0]), float(pts[0][1])
+        if d >= dists[-1]:
+            return float(pts[-1][0]), float(pts[-1][1])
+        for i in range(1, len(dists)):
+            if dists[i] >= d:
+                seg_len = dists[i] - dists[i-1]
+                if seg_len < 1e-9:
+                    return float(pts[i][0]), float(pts[i][1])
+                t = (d - dists[i-1]) / seg_len
+                x = pts[i-1][0] + t * (pts[i][0] - pts[i-1][0])
+                y = pts[i-1][1] + t * (pts[i][1] - pts[i-1][1])
+                return x, y
+        return float(pts[-1][0]), float(pts[-1][1])
 
     def _render_feature(self, surface: pygame.Surface, feature: NavFeature):
         if not feature.coords: return
@@ -773,7 +883,7 @@ class NAVViewer:
 
         for f in self.cached_features:
             # By type
-            type_name = ['?', 'Point', 'Line', 'Polygon', 'Text'][f.geom_type if f.geom_type < 5 else 0]
+            type_name = ['?', 'Point', 'Line', 'Polygon', 'Text', 'TextLine'][f.geom_type if f.geom_type < 6 else 0]
             stats['by_type'][type_name] = stats['by_type'].get(type_name, 0) + 1
 
             # By priority


### PR DESCRIPTION
## Summary

- New geometry type `GEOM_TEXT_LINE` (5): polyline + text string for text-along-path rendering
- River, canal and stream names follow the waterway curve instead of being placed as static point labels
- Labels are spaced along the waterway with alternating sub-segment positions to spread them naturally

## Details

- **osmium_handler**: `create_waterway_label()` extracts a path sub-segment (25–75% of way), with variable spacing per type (river=4, canal=8, stream=12) and 3 alternating positions
- **tile_processor**: `resolve_text_labels()` handles `GEOM_TEXT_LINE` with bbox-based collision detection and multi-tile expansion; serialization writes `path_count` + int16 coordinate pairs + text payload
- **tile_viewer**: parses `GEOM_TEXT_LINE`, renders characters along path with per-character rotation and automatic left-to-right flip
- **nav_types**: `GEOM_TEXT_LINE = 5`

## Zoom levels
- `river` → z10
- `canal` → z12
- `stream` → z14